### PR TITLE
Fix track mappings

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -253,7 +253,17 @@ def save_race_data_to_db(race_data, main_page_url):
             if not track_name_base:
                 track_name_mapping_fallback = {
                     'THISTLEDOW': 'Thistledown',
-                    'Tdn': 'Thistledown',
+                    'TDN': 'Thistledown',
+                    'BEL': 'Belmont Park',
+                    'SAR': 'Saratoga',
+                    'DMR': 'Del Mar',
+                    'OP': 'Oaklawn Park',
+                    'TAM': 'Tampa Bay Downs',
+                    'LRL': 'Laurel Park',
+                    'MTH': 'Monmouth Park',
+                    'PIM': 'Pimlico',
+                    'AQU': 'Aqueduct',
+                    'WO': 'Woodbine',
                 }
                 track_name_base = track_name_mapping_fallback.get(track_code_short, None)
                 

--- a/utils/race_parser.py
+++ b/utils/race_parser.py
@@ -9,10 +9,20 @@ logger = logging.getLogger(__name__)
 TRACK_CODES = {
     "gulfstream-park": "GP",
     "santa-anita-park": "SA",
-    "SANTA-ANIT": "SA",  # Código largo también mapea a SA
+    "SANTA-ANIT": "SA",  # Variante abreviada usada en algunas URLs
     "keeneland": "KEE",
     "churchill-downs": "CD",
-    "thistledown": "THISTLEDOW",
+    "belmont-park": "BEL",
+    "oaklawn-park": "OP",
+    "del-mar": "DMR",
+    "tampa-bay-downs": "TAM",
+    "laurel-park": "LRL",
+    "saratoga": "SAR",
+    "monmouth-park": "MTH",
+    "pimlico": "PIM",
+    "aqueduct": "AQU",
+    "woodbine": "WO",
+    "thistledown": "TDN",
     # Añadir más mapeos según sea necesario
 }
 


### PR DESCRIPTION
## Summary
- expand official track code map to prevent malformed race_id values
- improve fallback mappings when saving race data

## Testing
- `python -m py_compile utils/race_parser.py database/models.py`

------
https://chatgpt.com/codex/tasks/task_e_684bf18de56c832aa866d8fe19442782